### PR TITLE
Update auto-size-input.directive.ts

### DIFF
--- a/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
@@ -50,7 +50,7 @@ export class AutoSizeInputDirective implements AfterContentChecked
 	}
 
 	@HostListener('input', ['$event.target'])
-	public onInput():void
+	public onInput(event: Event):void
 	{
 		this.updateWidth();
 	}


### PR DESCRIPTION
This library is breaking the production build (when running with aot).
Please see:
https://stackoverflow.com/questions/48163344/angular-aot-error-in-ng-component-html-file-expected-0-arguments-but-got-1/48172467

This MR fixes this