### PR TITLE
fix: afterViewInit subscription

### DIFF
--- a/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
@@ -2,7 +2,7 @@ import {
 	AfterContentChecked, AfterViewInit, Directive, ElementRef, HostListener, Inject, Input, Optional, Renderer2,
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
-import { first } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 import {
 	AUTO_SIZE_INPUT_OPTIONS, AutoSizeInputOptions, DEFAULT_AUTO_SIZE_INPUT_OPTIONS,
 } from './auto-size-input.options';
@@ -49,7 +49,12 @@ export class AutoSizeInputDirective implements AfterContentChecked, AfterViewIni
 	}
 
 	ngAfterViewInit() {
-		if (this.ngModel) this.ngModel.valueChanges.pipe(first()).subscribe(() => this.updateWidth());
+		if (this.ngModel) {
+			this.ngModel.valueChanges.pipe(
+				filter(val => !!val), 
+				take(1)
+			).subscribe(() => this.updateWidth());
+		}
 	}
 
 	@HostListener('input', ['$event.target'])


### PR DESCRIPTION
- `first()` breaks our current implementations of a custom DateTime input which we receive a default text value and the DateTime input will try to convert it to a proper Date. `first()` skips the second emission of `valueChanges` when the proper Date is constructed
- `filter()` to filter out `empty string`, `null`, and `undefined` since this subscription runs in afterViewInit (ideally once) so if the value is `''/undefined/null`, it is ok to skip with `filter()`. The subsequent changes are captured by `HostListener`
- `take(1)` to complete the stream which effectively unsubscribes the stream after one emission.