### PR TITLE
feat: Add usePlaceholderWhenEmpty configuration option

### DIFF
--- a/projects/ngx-autosize-input-tester/src/app/app.component.ts
+++ b/projects/ngx-autosize-input-tester/src/app/app.component.ts
@@ -15,9 +15,36 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       [(ngModel)]="name"
       type="text"
     >
+    <br>
+    <br>
+    <label>
+      Enter and remove text in the input with a placeholder below
+    </label>
+    <br>
+    <input
+      autoSizeInput
+      placeholder="Input size should never be smaller then this string"
+      [(ngModel)]="withPlaceholder"
+      type="text"
+    >
+    <br>
+    <br>
+    <label>
+      Input below should fit to placeholder only when it's visible, otherwise fit to text entered by user
+    </label>
+    <br>
+    <input
+      autoSizeInput
+      placeholder="Should fit to whatever text is displayed"
+      [usePlaceHolderWhenEmpty]="true"
+      [(ngModel)]="placeHolderWhenEmpty"
+      type="text"
+    >
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
-	name: string;
+  name: string;
+  withPlaceholder: string;
+  placeHolderWhenEmpty: string;
 }

--- a/projects/ngx-autosize-input-tester/src/app/app.module.ts
+++ b/projects/ngx-autosize-input-tester/src/app/app.module.ts
@@ -13,6 +13,7 @@ const CUSTOM_AUTO_SIZE_INPUT_OPTIONS: AutoSizeInputOptions = {
 	maxWidth: -1,
 	minWidth: -1,
 	setParentWidth: false,
+	usePlaceHolderWhenEmpty: false
 }
 
 @NgModule({

--- a/projects/ngx-autosize-input/src/lib/auto-size-input.directive.spec.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.directive.spec.ts
@@ -2,7 +2,7 @@ import { AutoSizeInputDirective } from './auto-size-input.directive';
 
 describe('AutoSizeInputDirective', () => {
 	it('should create an instance', () => {
-		const directive = new AutoSizeInputDirective({} as any, {} as any, {} as any);
+		const directive = new AutoSizeInputDirective({} as any, {} as any, {} as any, {} as any);
 		expect(directive).toBeTruthy();
 	});
 });

--- a/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
@@ -20,6 +20,7 @@ export class AutoSizeInputDirective implements AfterViewInit, OnDestroy {
 	@Input() maxWidth = this.defaultOptions.maxWidth;
 	@Input() minWidth = this.defaultOptions.minWidth;
 	@Input() setParentWidth = this.defaultOptions.setParentWidth;
+	@Input() usePlaceHolderWhenEmpty = this.defaultOptions.usePlaceHolderWhenEmpty;
 	private destroy$ = new Subject<void>();
 
 	constructor(
@@ -101,7 +102,15 @@ export class AutoSizeInputDirective implements AfterViewInit, OnDestroy {
 		} else if (setMaxWidth) {
 			this.setWidth(this.maxWidth);
 		} else {
-			this.setWidthUsingText(setPlaceHolderWidth ? placeHolderText : inputText);
+			let textForWidth: string;
+			// If user has usePlaceHolderWhenEmpty enabled, only use placeholder text for width
+			// if the input text is empty
+			if (setPlaceHolderWidth && (inputText.length === 0 || !this.usePlaceHolderWhenEmpty)) {
+				textForWidth = placeHolderText;
+			} else {
+				textForWidth = inputText;
+			}
+			this.setWidthUsingText(textForWidth);
 		}
 	}
 

--- a/projects/ngx-autosize-input/src/lib/auto-size-input.options.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.options.ts
@@ -10,6 +10,7 @@ export interface AutoSizeInputOptions {
 	maxWidth: number;
 	minWidth: number;
 	setParentWidth: boolean;
+	usePlaceHolderWhenEmpty: boolean;
 }
 
 export const DEFAULT_AUTO_SIZE_INPUT_OPTIONS: AutoSizeInputOptions = {
@@ -20,4 +21,5 @@ export const DEFAULT_AUTO_SIZE_INPUT_OPTIONS: AutoSizeInputOptions = {
 	maxWidth: -1,
 	minWidth: -1,
 	setParentWidth: false,
+	usePlaceHolderWhenEmpty: false,
 }


### PR DESCRIPTION
Add usePlaceholderWhenEmpty configuration option to only use placeholder for min width if there isn't any text in the input, i.e. only use the width of the placeholder if the placeholder is actually visible

This will close #32 