### PR TITLE
Add in support for reactive forms and Add in support for form controls that make use of input formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add extra width, in units of pixels.
 
 Default Value: 0px
 
-Example (add 10px): 
+Example (add 10px):
  ```
 <input autoSizeInput [extraWidth]="10">
 ```
@@ -85,7 +85,7 @@ Note that [minimumWidth] will override this property.
 
 Default Value: true
 
-Example (turn off placeholder): 
+Example (turn off placeholder):
  ```
 <input autoSizeInput [includePlaceholder]="false">
 ```
@@ -108,7 +108,7 @@ Includes padding width, so that text is not cut off.
 
 Default Value: true
 
-Example (turn off include padding): 
+Example (turn off include padding):
  ```
 <input autoSizeInput [includePadding]="false">
 ```
@@ -119,7 +119,7 @@ Sets minimum width, in units of pixels.
 
 Default Value: 0
 
-Example (50px minimum width): 
+Example (50px minimum width):
  ```
 <input autoSizeInput [minWidth]="50">
 ```
@@ -130,7 +130,7 @@ Sets maximum width, in units of pixels.
 
 Default Value: 0
 
-Example (100px maximum width): 
+Example (100px maximum width):
  ```
 <input autoSizeInput [maxWidth]="100">
 ```
@@ -141,7 +141,7 @@ Sets parent width automatically, instead of input width. Useful when you need to
 
 Default Value: false
 
-Example (input wrapped in an Angular Material form field component): 
+Example (input wrapped in an Angular Material form field component):
  ```
 <mat-form-field> // This will be resized
     <input autoSizeInput [setParentWidth]="true">
@@ -157,6 +157,21 @@ Default Value: false
 Example (turn on placeholder when empty):
  ```
 <input autoSizeInput [usePlaceholderWhenEmpty]="true">
+```
+
+### \[useValueProperty]
+
+If the value of the form control is an object but the input value is formatted setting this
+value to true will use the value property of the input instead of retreiving the value from
+the form control or model. This option is not globally configurable and must be set on each input.
+
+Default Value: false
+
+Example (ngbTypeahead with inputFormatter):
+`search$` returns an array of objects `{ firstName: string; lastName: string; }[]` and `formatInput` transforms the selected object to ``` `${firstName} ${lastName}` ```. The value applied to the form control will be the object
+selected so in-order to get the actual string value in the input we need to look at the value property.
+ ```
+<input autoSizeInput [useValueProperty]="true" formControlName="fullName" [ngbTypeahead]="search$" [inputFormatter]="formatInput">
 ```
 
 ## Author

--- a/projects/ngx-autosize-input-tester/src/app/app.component.ts
+++ b/projects/ngx-autosize-input-tester/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
 
 @Component({
 	selector: 'app-root',
@@ -40,11 +41,33 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       [(ngModel)]="placeHolderWhenEmpty"
       type="text"
     >
+    <br>
+    <br>
+    <fieldset [formGroup]="form">
+      <label>
+        Input below should fit to placeholder only when it's visible, otherwise fit to text entered by user
+      </label>
+      <br>
+      <input
+        autoSizeInput
+        placeholder="This input is using a form control name"
+        [usePlaceHolderWhenEmpty]="true"
+        formControlName="inputWithControlName"
+        type="text"
+      >
+    </fieldset>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   name: string;
   withPlaceholder: string;
   placeHolderWhenEmpty: string;
+  form: FormGroup;
+
+  ngOnInit(): void {
+    this.form = new FormGroup({
+      inputWithControlName: new FormControl('')
+    });
+  }
 }

--- a/projects/ngx-autosize-input-tester/src/app/app.module.ts
+++ b/projects/ngx-autosize-input-tester/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { AUTO_SIZE_INPUT_OPTIONS, AutoSizeInputModule, AutoSizeInputOptions } from 'ngx-autosize-input';
 
@@ -24,6 +24,7 @@ const CUSTOM_AUTO_SIZE_INPUT_OPTIONS: AutoSizeInputOptions = {
 		BrowserModule,
 		AutoSizeInputModule,
 		FormsModule,
+		ReactiveFormsModule,
 	],
 	providers: [
 		{ provide: AUTO_SIZE_INPUT_OPTIONS, useValue: CUSTOM_AUTO_SIZE_INPUT_OPTIONS }

--- a/projects/ngx-autosize-input/src/lib/auto-size-input.directive.spec.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.directive.spec.ts
@@ -2,7 +2,7 @@ import { AutoSizeInputDirective } from './auto-size-input.directive';
 
 describe('AutoSizeInputDirective', () => {
 	it('should create an instance', () => {
-		const directive = new AutoSizeInputDirective({} as any, {} as any, {} as any, {} as any);
+		const directive = new AutoSizeInputDirective({} as any, {} as any, {} as any, {} as any, {} as any);
 		expect(directive).toBeTruthy();
 	});
 });

--- a/projects/ngx-autosize-input/src/lib/auto-size-input.options.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.options.ts
@@ -10,7 +10,7 @@ export interface AutoSizeInputOptions {
 	maxWidth: number;
 	minWidth: number;
 	setParentWidth: boolean;
-	usePlaceHolderWhenEmpty: boolean;
+	usePlaceHolderWhenEmpty?: boolean;
 }
 
 export const DEFAULT_AUTO_SIZE_INPUT_OPTIONS: AutoSizeInputOptions = {


### PR DESCRIPTION
Users can now use formControlName="name" instead of just being able to use ngModel. This provides support for reactive forms. In addition, I also added the ability for users to specify that they only want to look at the value property of the input when measuring the width. This is useful if the input control value accessor is bound to an object, but the input view value is as formatted string representation of the object. (I needed this to support ngbTypeaheads with inputFormatters).

This will close #34 
