### PR TITLE
Expose AutoSizeInputDirective in public api

### DIFF
--- a/projects/ngx-autosize-input/src/public-api.ts
+++ b/projects/ngx-autosize-input/src/public-api.ts
@@ -2,5 +2,6 @@
  * Public API Surface of ngx-autosize-input
  */
 
+export * from './lib/auto-size-input.directive';
 export * from './lib/auto-size-input.options';
 export * from './lib/auto-size-input.module';


### PR DESCRIPTION
Adds `AutoSizeInputDirective` to the public api definition.

This allows the directive to be used when required for injecting into components/directives.

Our use case for this is ensuring the width is updated when used in combination with [ngrx-forms](https://github.com/MrWolfZ/ngrx-forms). 