### PR TITLE
Fix border width calculation in Firefox.

### DIFF
--- a/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
+++ b/projects/ngx-autosize-input/src/lib/auto-size-input.directive.ts
@@ -34,7 +34,7 @@ export class AutoSizeInputDirective implements AfterViewInit, OnDestroy {
 	}
 
 	get borderWidth(): number {
-		return this.includeBorders ? this._sumPropertyValues(['border-right', 'border-left']) : 0;
+		return this.includeBorders ? this._sumPropertyValues(['border-right-width', 'border-left-width']) : 0;
 	}
 
 	get defaultOptions() {

--- a/projects/ngx-autosize-input/src/lib/width-properties.type.ts
+++ b/projects/ngx-autosize-input/src/lib/width-properties.type.ts
@@ -1,1 +1,1 @@
-export type WidthProperty = 'border-left'|'border-right'|'padding-left'|'padding-right';
+export type WidthProperty = 'border-left-width'|'border-right-width'|'padding-left'|'padding-right';


### PR DESCRIPTION
In Firefox I noticed that the border width calculation does not work right. `getComputedStyle(element, '').getPropertyValue('border-right')` returns an empty string and when fed into `parseInt` returns `NaN`. This effectively resets the input width to its default size.

See in Firefox:
https://stackblitz.com/edit/ngx-autosize-input-10-sspiu1?file=src/app/app.component.html

![image](https://user-images.githubusercontent.com/11789131/129989071-aa91f105-9245-452e-87dd-f1d410351180.png)

By using `border-*-width` instead of `border-*`, the function `getPropertyValue('border-*-width')` returns a px value.